### PR TITLE
Python 3, HTTPS, disable title case

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,8 @@ setup(name='python-usps2',
       long_description=LONG_DESC,
       classifiers=[
           'Programming Language :: Python',
+          'Programming Language :: Python :: 2',
+          'Programming Language :: Python :: 3',
           'Operating System :: OS Independent',
           'Natural Language :: English',
           'Development Status :: 5 - Production/Stable',

--- a/tests.py
+++ b/tests.py
@@ -10,8 +10,8 @@ class TestAddressInformationAPI(unittest.TestCase):
         address_validation = Address(url=USPS_CONNECTION_TEST, user_id=USERID)
         response = address_validation.validate(address2='6406 Ivy Lane', city='Greenbelt', state='MD')
 
-        self.assertEqual(response['Address2'], '6406 Ivy Ln')
-        self.assertEqual(response['City'], 'Greenbelt')
+        self.assertEqual(response['Address2'], '6406 IVY LN')
+        self.assertEqual(response['City'], 'GREENBELT')
         self.assertEqual(response['State'], 'MD')
         self.assertEqual(response['Zip5'], '20770')
         self.assertEqual(response['Zip4'], '1441')

--- a/usps/addressinformation/__init__.py
+++ b/usps/addressinformation/__init__.py
@@ -1,4 +1,4 @@
-from base import USPSXMLError, Address
+from usps.addressinformation.base import USPSXMLError, Address
 
 USPS_CONNECTION = 'https://secure.shippingapis.com/ShippingAPI.dll'
 USPS_CONNECTION_TEST = 'https://secure.shippingapis.com/ShippingAPITest.dll'

--- a/usps/addressinformation/__init__.py
+++ b/usps/addressinformation/__init__.py
@@ -1,5 +1,5 @@
 from base import USPSXMLError, Address
 
-USPS_CONNECTION = 'http://production.shippingapis.com/ShippingAPI.dll'
-USPS_CONNECTION_TEST_SECURE = 'https://secure.shippingapis.com/ShippingAPITest.dll'
-USPS_CONNECTION_TEST = 'http://testing.shippingapis.com/ShippingAPITest.dll'
+USPS_CONNECTION = 'https://secure.shippingapis.com/ShippingAPI.dll'
+USPS_CONNECTION_TEST = 'https://secure.shippingapis.com/ShippingAPITest.dll'
+USPS_CONNECTION_TEST_SECURE = USPS_CONNECTION_TEST

--- a/usps/addressinformation/base.py
+++ b/usps/addressinformation/base.py
@@ -45,8 +45,8 @@ class USPSAddressService(object):
     API = None
     CHILD_XML_NAME = None
     PARAMETERS = None
-    
-    def __init__(self, url='http://production.shippingapis.com/ShippingAPI.dll'):
+
+    def __init__(self, url='https://secure.shippingapis.com/ShippingAPI.dll'):
         self.url = url
 
     def submit_xml(self, xml):

--- a/usps/addressinformation/base.py
+++ b/usps/addressinformation/base.py
@@ -129,24 +129,26 @@ class Address(USPSAddressService):
         super(Address, self).__init__(*args, **kwargs)
         self.USER_ID = user_id
 
-    def format_response(self, address_dict):
+    def format_response(self, address_dict, title_case):
         """ Format the response with title case.  Ensures
         that the address is "Human Readable"
         """
 
-        if 'Address1' in address_dict:
-            address_dict['Address1'] = address_dict['Address1'].title()
+        if title_case:
+            if 'Address1' in address_dict:
+                address_dict['Address1'] = address_dict['Address1'].title()
 
-        if 'FirmName' in address_dict:
-            address_dict['FirmName'] = address_dict['FirmName'].title()
+            if 'FirmName' in address_dict:
+                address_dict['FirmName'] = address_dict['FirmName'].title()
 
-        address_dict['Address2'] = address_dict['Address2'].title()
-        address_dict['City'] = address_dict['City'].title()
+            address_dict['Address2'] = address_dict['Address2'].title()
+            address_dict['City'] = address_dict['City'].title()
         address_dict['FullZip'] = "%s-%s" % (address_dict['Zip5'], address_dict['Zip4'])
 
         return address_dict
 
-    def validate(self, firm_name='', address1='', address2='', city='', state='', zip_5='', zip_4=''):
+    def validate(self, firm_name='', address1='', address2='', city='', state='', zip_5='', zip_4='',
+                 title_case=False):
         """ Validate provides a cleaner more verbose way to call the API.
         Repackages the attributes
         """
@@ -159,6 +161,4 @@ class Address(USPSAddressService):
                         'Zip4': zip_4}
 
         valid_address = self.execute(self.USER_ID, [address_dict])
-        return self.format_response(valid_address[0])
-
-
+        return self.format_response(valid_address[0], title_case)

--- a/usps/addressinformation/base.py
+++ b/usps/addressinformation/base.py
@@ -77,7 +77,7 @@ class USPSAddressService(object):
         for item in xml.getchildren():
             items.append(xmltodict(item))
         return items
-    
+
     def make_xml(self, userid, addresses):
         root = ET.Element(self.SERVICE_NAME + 'Request')
         root.attrib['USERID'] = userid
@@ -87,7 +87,7 @@ class USPSAddressService(object):
             address_xml.attrib['ID'] = str(index)
             index += 1
         return root
-    
+
     def execute(self, userid, addresses):
         xml = self.make_xml(userid, addresses)
         return self.parse_xml(self.submit_xml(xml))
@@ -153,7 +153,11 @@ class Address(USPSAddressService):
 
             address_dict['Address2'] = address_dict['Address2'].title()
             address_dict['City'] = address_dict['City'].title()
-        address_dict['FullZip'] = "%s-%s" % (address_dict['Zip5'], address_dict['Zip4'])
+        if address_dict['Zip4']:
+            address_dict['FullZip'] = "%s-%s" % (
+                address_dict['Zip5'], address_dict['Zip4'])
+        else:
+            address_dict['FullZip'] = address_dict['Zip5']
 
         return address_dict
 


### PR DESCRIPTION
 * Support for Python 3. Python 2 still works.
 * Use HTTPS by default. You can still pass HTTP URLs of course.
 * Disable title case by default but still expose it as an argument. I prefer USPS uppercase to "102Nd St" etc.