### PR TITLE
Issue #6 - Python 3.10 support, bug fixes, and refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ run.py
 .idea
 *.egg-info/
 dist/
+/bin/
+/lib/
+/pyvenv.cfg

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+lxml==4.9.1
+xmltodict==0.13.0

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from setuptools import setup, find_packages
 
-VERSION = '0.2.0'
+VERSION = '0.3.0'
 LONG_DESC = """\
 A python wrapper to the USPS api, currently only supports address validation
 """
@@ -13,7 +13,6 @@ setup(name='python-usps2',
       long_description=LONG_DESC,
       classifiers=[
           'Programming Language :: Python',
-          'Programming Language :: Python :: 2',
           'Programming Language :: Python :: 3',
           'Operating System :: OS Independent',
           'Natural Language :: English',
@@ -31,6 +30,7 @@ setup(name='python-usps2',
       packages=find_packages(),
       zip_safe=False,
       install_requires=[
+          'lxml',
+          'xmltodict'
       ],
-
       )

--- a/tests.py
+++ b/tests.py
@@ -131,7 +131,6 @@ class TestAddressInformationAPI(unittest.TestCase):
         })
 
         xml = rate.make_xml(package_dicts=[package_dict_one, package_dict_two])
-        print_xml(xml)
         response_xml = rate.submit_xml(xml)
         return_dict = xmltodict.parse(ElementTree.tostring(response_xml))
 

--- a/tests.py
+++ b/tests.py
@@ -1,32 +1,56 @@
+import os
 import unittest
-from xml.etree import ElementTree as ET
+import random
+from datetime import datetime, timedelta
 from xml.dom import minidom
-from usps.addressinformation import *
-USERID = None
-import xmltodict
-import json
-from constants import CARRIER_PICKUP_SCHEDULE_REQUEST_SERVICE_TYPE
+from xml.etree import ElementTree
 
-USERID = ""
+import xmltodict
+
+from constants import CARRIER_PICKUP_SCHEDULE_REQUEST_SERVICE_TYPE
+from usps.addressinformation import *
+
+USERID = os.environ.get('USERID')  # A user id must be defined in the environment variables to run the test
 USPS_CONNECTION_TEST = 'https://secure.shippingapis.com/ShippingAPITest.dll'
 USPS_CONNECTION_HTTP = 'http://production.shippingapis.com/ShippingAPI.dll'
+
+
+# USPS cares about the order of the arbitrary order that the data submitted, but normal users shouldn't.
+# Let's shuffle the data to ensure that it can be inputted in any order.
+def randomize_dict(obj):
+    # Python 3.7+ maintains ordering in dicts
+    randomized = {}
+    keys = list(obj.keys())
+    random.shuffle(keys)
+    for key in keys:
+        if isinstance(obj[key], dict):
+            randomized[key] = randomize_dict(obj[key])
+        else:
+            randomized[key] = obj[key]
+
+    return randomized
+
+
+def print_xml(xml):
+    print(minidom.parseString(ElementTree.tostring(xml)).toprettyxml(indent="    "))
+
 class TestAddressInformationAPI(unittest.TestCase):
 
     def test_validate_address(self):
+        self.assertIsNotNone(USERID)
         address_validation = Address(user_id=USERID, url=USPS_CONNECTION_TEST)
         response = address_validation.validate(address2='760 Charcot Ave', city='San Jose', state='CA')
-        print(response)
-        # print(minidom.parseString(ET.tostring(response_xml)).toprettyxml(indent="    "))
 
-    def test_package_makexml(self):
+    def test_domestic_rate_make_xml(self):
         """
         test rate
         Returns:
 
         """
+        self.assertIsNotNone(USERID)
         rate = DomesticRate(user_id=USERID, url=USPS_CONNECTION_TEST)
 
-        package_dict_one = {
+        package_dict_one = randomize_dict({
             'Service': 'FIRST CLASS',
             'FirstClassMailType': 'LETTER',
             'ZipOrigination': 44106,
@@ -36,9 +60,8 @@ class TestAddressInformationAPI(unittest.TestCase):
             'Container': '',
             'Size': 'REGULAR',
             'Machinable': True
-        }
-
-        package_dict_two = {
+        })
+        package_dict_two = randomize_dict({
             'Service': 'PRIORITY',
             'ZipOrigination': 44106,
             'ZipDestination': 20770,
@@ -58,11 +81,11 @@ class TestAddressInformationAPI(unittest.TestCase):
                 {
                     'SpecialService': 2
                 }]
-        }
-        xml = rate.make_xml(package_dicts=[package_dict_one, package_dict_two])
-        print(minidom.parseString(ET.tostring(xml)).toprettyxml(indent="    "))
+        })
 
-    def test_make_rate_request(self):
+        xml = rate.make_xml(package_dicts=[package_dict_one, package_dict_two])
+
+    def test_domestic_rate_submit(self):
         """
         test rate xml construction and api call
         Returns:
@@ -70,26 +93,24 @@ class TestAddressInformationAPI(unittest.TestCase):
         """
         rate = DomesticRate(user_id=USERID, url=USPS_CONNECTION_TEST)
 
-        package_dict_one = {
+        package_dict_one = randomize_dict({
             'Service': 'FIRST CLASS',
             'FirstClassMailType': 'LETTER',
             'ZipOrigination': 44106,
             'ZipDestination': 20770,
             'Pounds': 0,
-            'Ounces': float(3.12345678),
+            'Ounces': 3.12345678,
             'Container': 'VARIABLE',
-            'Size': 'REGULAR',
             'Machinable': True
-        }
+        })
 
-        package_dict_two = {
+        package_dict_two = randomize_dict({
             'Service': 'PRIORITY',
             'ZipOrigination': 44106,
             'ZipDestination': 20770,
             'Pounds': 1,
             'Ounces': 8,
             'Container': 'NONRECTANGULAR',
-            'Size': 'LARGE',
             'Width': 15,
             'Length': 30,
             'Height': 15,
@@ -107,19 +128,18 @@ class TestAddressInformationAPI(unittest.TestCase):
                     'ContentType': 'LIVES',
                     'ContentDescription': 'Other'
                 }
-        }
+        })
 
         xml = rate.make_xml(package_dicts=[package_dict_one, package_dict_two])
-        print(minidom.parseString(ET.tostring(xml)).toprettyxml(indent="    "))
+        print_xml(xml)
         response_xml = rate.submit_xml(xml)
-        print(minidom.parseString(ET.tostring(response_xml)).toprettyxml(indent="    "))
-        return_dict = xmltodict.parse(ET.tostring(response_xml))
-        print(json.loads(json.dumps(return_dict)))
+        return_dict = xmltodict.parse(ElementTree.tostring(response_xml))
 
+        self.assertTrue('RateV4Response' in return_dict and 'Package' in return_dict.get('RateV4Response'))
+        self.assertTrue(len(return_dict['RateV4Response']['Package']) == 2)
 
-    def test_intelRate(self):
-
-        package_dict_two = {
+    def test_intel_rate_v2_submit(self):
+        package_dict_two = randomize_dict({
             'Pounds': 1,
             'Ounces': 8,
             'MailType': 'Package',
@@ -141,41 +161,37 @@ class TestAddressInformationAPI(unittest.TestCase):
                 {
                     'ExtraService': 106
                 }
-                ],
+            ],
             'Content':
                 {
                     'ContentType': 'Documents',
                     'ContentDescription': 'Other'
                 }
-        }
+        })
+
+        self.assertIsNotNone(USERID)
 
         intl = IntlRateV2(user_id=USERID, )
         xml = intl.make_xml(package_dicts=[package_dict_two])
-        print(minidom.parseString(ET.tostring(xml)).toprettyxml(indent="    "))
         response_xml = intl.submit_xml(xml)
-        print(intl.to_json(response_xml))
 
-    def test_tracker(self):
-        """
-        test tracker
-        Returns:
-
-        """
-        tracker = Track(user_id="766POSTG6978",url=USPS_CONNECTION_TEST)
+    def test_tracker_submit(self):
+        tracker = Track(user_id="766POSTG6978", url=USPS_CONNECTION_TEST)
         tracker_ids = ['9405536897846333893331']
         xml = tracker.make_xml(tracker_ids=tracker_ids)
-        print(minidom.parseString(ET.tostring(xml)).toprettyxml(indent="    "))
-        response_xml = tracker.submit_xml(xml)
-        print(minidom.parseString(ET.tostring(response_xml)).toprettyxml(indent="    "))
 
-    def test_carrier_pickup_availability(self):
-        """
-        test carrier pickup availability
-        Returns:
+        # USPS doesn't seem to offer sandbox or testing tracking numbers so lets just check against a
+        # valid not found response
+        with self.assertRaises(USPSXMLError) as context:
+            tracker.submit_xml(xml)
 
-        """
-        avail = CarrierPickupAvailability(user_id='766POSTG6978',url=USPS_CONNECTION_TEST)
-        request_dict = {
+        self.assertTrue(
+            'A status update is not yet available on your Priority Mail' in context.exception.info.get('Description'))
+
+    def test_carrier_pickup_availability_submit(self):
+        self.assertIsNotNone(USERID)
+        avail = CarrierPickupAvailability(user_id=USERID, url=USPS_CONNECTION_TEST)
+        request_dict = randomize_dict({
             "FirmName": "PostGround Corp",
             "SuiteOrApt": "Suite777",
             "Address2": "760 Charcot Ave",
@@ -184,23 +200,16 @@ class TestAddressInformationAPI(unittest.TestCase):
             "State": "CA",
             "ZIP5": "95131",
             "ZIP4": "2223"
-        }
+        })
         xml = avail.make_xml(
             pickup_availability_dict=request_dict
         )
-        print(minidom.parseString(ET.tostring(xml)).toprettyxml(indent="    "))
         response_xml = avail.submit_xml(xml)
-        print(avail.to_json(response_xml))
 
-    def test_carrier_pickup_schedule(self):
-        """
-
-        No test api
-        Returns:
-
-        """
+    def test_carrier_pickup_schedule_submit(self):
+        self.assertIsNotNone(USERID)
         schedule = CarrierPickupSchedule(user_id=USERID, url=USPS_CONNECTION_TEST)
-        request_dict = {
+        request_dict = randomize_dict({
             "FirstName": "Luyi",
             "LastName": "Doe",
             "FirmName": "PostGround Corp",
@@ -226,20 +235,14 @@ class TestAddressInformationAPI(unittest.TestCase):
             "EstimatedWeight": "14",
             "PackageLocation": "Front Door",
             "SpecialInstructions": "Behind the screen door"
-        }
+        })
         xml = schedule.make_xml(pickup_schedule_dict=request_dict)
-        print(minidom.parseString(ET.tostring(xml)).toprettyxml(indent="    "))
         response_xml = schedule.submit_xml(xml)
-        print(schedule.to_json(response_xml))
 
-    def test_carrier_pickup_cancel(self):
-        """
-        No test api
-        Returns:
-
-        """
+    def test_carrier_pickup_cancel_make_xml(self):
+        self.assertIsNotNone(USERID)
         pickup_cancel = CarrierPickupCancel(user_id=USERID, url=USPS_CONNECTION_TEST)
-        request_dict = {
+        request_dict = randomize_dict({
             "FirmName": "PostGround Corp",
             "SuiteOrApt": "Suite777",
             "Address2": "760 Charcot Ave",
@@ -249,19 +252,14 @@ class TestAddressInformationAPI(unittest.TestCase):
             "ZIP5": "95131",
             "ZIP4": "2223",
             "ConfirmationNumber": "XXXXXX"
-        }
+        })
         xml = pickup_cancel.make_xml(pickup_cancel_dict=request_dict)
-        print(minidom.parseString(ET.tostring(xml)).toprettyxml(indent="    "))
 
-    def test_carrier_pickup_change(self):
-        """
-
-        No test api
-        Returns:
-
-        """
+    def test_carrier_pickup_change_make_xml(self):
+        # https://www.usps.com/business/web-tools-apis/service-delivery-calculator-get-locations-api.htm
+        self.assertIsNotNone(USERID)
         schedule = CarrierPickupChange(user_id=USERID, url=USPS_CONNECTION_TEST)
-        request_dict = {
+        request_dict = randomize_dict({
             "FirstName": "Luyi",
             "LastName": "Doe",
             "FirmName": "PostGround Corp",
@@ -287,41 +285,35 @@ class TestAddressInformationAPI(unittest.TestCase):
             "EstimatedWeight": "14",
             "PackageLocation": "Front Door",
             "SpecialInstructions": "Behind the screen door",
-            "ConfirmationNumber" :"xxxx"
+            "ConfirmationNumber": "xxxx"
 
-        }
+        })
         xml = schedule.make_xml(pickup_schedule_change_dict=request_dict)
-        print(minidom.parseString(ET.tostring(xml)).toprettyxml(indent="    "))
 
-
-    def test_mail_service(self):
-        SERVICE_NAME = ['PriorityMail', 'StandardB', 'FirstClassMail', 'ExpressMailCommitment']
+    def test_mail_services_make_xml(self):
+        self.assertIsNotNone(USERID)
         mail_service = MailService(user_id=USERID, url=USPS_CONNECTION_TEST)
-        request_dict ={
+        request_dict = randomize_dict({
             "OriginZip": "95131",
             "DestinationZip": "21114"
-        }
-        for service_name in SERVICE_NAME:
-            xml = mail_service.make_xml(mail_service_dict=request_dict,service_name=service_name)
-            print(minidom.parseString(ET.tostring(xml)).toprettyxml(indent="    "))
+        })
+        for service_name in MailService.SERVICE_NAMES:
+            xml = mail_service.make_xml(mail_service_dict=request_dict, service_name=service_name)
 
-    def test_sdcgetlocation(self):
-        sdcgl = ServiceDelivery(user_id=USERID, url=USPS_CONNECTION_HTTP)
-        request_dict = {
+    def test_sdc_get_location(self):
+        self.assertIsNotNone(USERID)
+        service_delivery = ServiceDelivery(user_id=USERID, url=USPS_CONNECTION_HTTP)
+        request_dict = randomize_dict({
             "MailClass": "0",
             "OriginZIP": "70601",
             "DestinationZIP": "98101",
-            "AcceptDate": "30-April-2018",
+            "AcceptDate": (datetime.now() + timedelta(days=1)).strftime('%d-%B-%Y'),
             "AcceptTime": "0900",
             "NonEMDetail": "True",
-        }
-        xml = sdcgl.make_xml(sdc_get_location_dict=request_dict)
-        print(minidom.parseString(ET.tostring(xml)).toprettyxml(indent="    "))
-        response_xml = sdcgl.submit_xml(xml)
-        print(sdcgl.to_json(response_xml))
+        })
+        xml = service_delivery.make_xml(sdc_get_location_dict=request_dict)
+        response_xml = service_delivery.submit_xml(xml)
 
 
 if __name__ == '__main__':
-    #please append your USPS USERID to test against the wire
-    import sys
     unittest.main()


### PR DESCRIPTION
Fixes Issue: https://github.com/wangluyi1982/python-usps/issues/6

Added support for python 3.9 and 3.10. Fixed problems where the USPS api would reject results due to the ordering of the data sent to it. Refactored ServiceDelivery.make_xml to not take in a redundant user id. Moved the user id to the environment variables to make it easier to configure and remove the possibility of accidentally committing it to a repo. Reformatted file and imports. Added requirements to the setup and created a requirements.txt file to make it easier to setup. Fixed a problem where errors would not unescape the text so it could contain unreadable content. Added virtual environment paths and files to the git ignore.